### PR TITLE
Added support for Ubuntu 20.04 Focal Fossa

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 
 
 INSTALL_DIR=/opt
-MOTION_VER=4.2.2
+MOTION_VER=4.3.2
 
 update_only='false'
 developer_versions='false'
@@ -136,17 +136,17 @@ install_motion_auto () {
     # Only install prebuilt binaries which are available only on supported OSs
     if [ $DETECTED_OS == "ubuntu" ] || [ $DETECTED_OS == "debian" ] || [ $DETECTED_OS == "raspbian" ]
     then
-        if [ $DETECTED_CODENAME == "bionic" ] || [ $DETECTED_CODENAME == "cosmic" ] || [ $DETECTED_CODENAME == "buster" ]
+        if [ $DETECTED_CODENAME == "bionic" ] || [ $DETECTED_CODENAME == "cosmic" ] || [ $DETECTED_CODENAME == "buster" ] || [ $DETECTED_CODENAME == "focal" ]
         then
             echo -e "\nDownloading Motion..."
             
             if [ $DETECTED_OS == "raspbian" ]
             then 
                 # Get the armhf binaries (with the pi prefix) for Raspbian
-                wget https://github.com/Motion-Project/motion/releases/download/release-4.2.2/pi_${DETECTED_CODENAME}_motion_${MOTION_VER}-1_armhf.deb -O motion.deb
+                wget https://github.com/Motion-Project/motion/releases/download/release-${MOTION_VER}/pi_${DETECTED_CODENAME}_motion_${MOTION_VER}-1_armhf.deb -O motion.deb
             else
                 # For x86 systems, just use the normal amd64 binaries
-                wget https://github.com/Motion-Project/motion/releases/download/release-4.2.2/${DETECTED_CODENAME}_motion_${MOTION_VER}-1_amd64.deb -O motion.deb
+                wget https://github.com/Motion-Project/motion/releases/download/release-${MOTION_VER}/${DETECTED_CODENAME}_motion_${MOTION_VER}-1_amd64.deb -O motion.deb
             fi
 
             echo -e "\nInstalling Motion..."


### PR DESCRIPTION
# Description

Add precompiled Motion binaries for Ubuntu 20.04 & bump Motion version to 4.3.2.

Closes/Fixes #(issue number)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Re-write of an existing feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency Update

# Testing

Tested on hardware (SART MkII) (a fancy robot that's better than the newer stuff they come out with these days)

# Final checklist:

- [x] Code follows the style guidelines of Sights
- [x] I have performed a self-review of my own code
- [x] Comments have been added, particularly in hard-to-understand areas
- [x] Made corresponding changes to the documentation
- [x] The changes cause no new errors or warnings
